### PR TITLE
Added tapering

### DIFF
--- a/Hyperbolic15PNhphc.py
+++ b/Hyperbolic15PNhphc.py
@@ -38,12 +38,16 @@ def hyperbolic_waveform_td(**kwds):
                     m1, m2, et0, R, Theta, delta_t, phi0)
     hp = TimeSeries(hp, delta_t)
     hc = TimeSeries(hc, delta_t)
-    # Find the peak time and shift the time axis
+    # Find the peak time and shift both hp and hc (in time) with the same amount
     t_shift = hp.sample_times[np.argmax(hp)]
+    t_shift = hc.sample_times[np.argmax(hp)]
 
     hp = TimeSeries(hp.data, delta_t, epoch=-t_shift)
     hc = TimeSeries(hc.data, delta_t, epoch=-t_shift)
-    return hp, hc
+
+    hp_tapered = hp.taper_timeseries('TAPER_STARTEND')
+    hc_tapered = hc.taper_timeseries('TAPER_STARTEND')
+    return hp_tapered, hc_tapered
 
 
 def hyperbolic_waveform_fd(**kwds):


### PR DESCRIPTION
The time-domain waveforms do not go to zero on either ends. Added tapering on both sides to solve this issue (see the plot below).

I have used the `taper_timeseries` method to implement the above. 



<img width="662" height="505" alt="image" src="https://github.com/user-attachments/assets/be09a6a2-b308-4b35-8e1a-ef00e434dd76" />